### PR TITLE
perf(reports): remove N+1 in InboundService product summaries

### DIFF
--- a/app/Services/InboundService.php
+++ b/app/Services/InboundService.php
@@ -8,22 +8,23 @@ use App\Models\ProductType;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-
 // ! ALL STATIC FUNCTIONS
 class InboundService extends Model
 {
     use HasFactory;
 
-    public static function getTotalOfInboundProducts($inboundId){
+    public static function getTotalOfInboundProducts($inboundId)
+    {
         $inbound = Inbound::find($inboundId);
         $products = json_decode($inbound->products, true);
         $total = 0;
 
-        if($products){
-            foreach($products as $product){
+        if ($products) {
+            foreach ($products as $product) {
                 $total += $product['quantity'] * $product['price'];
             }
         }
+
         return $total;
     }
 
@@ -32,87 +33,85 @@ class InboundService extends Model
 
         $inbound = BadOrder::ofInboundId($inboundId)->get();
 
-        if($inbound){
+        if ($inbound) {
 
             $total = 0;
-            foreach($inbound as $badOrder){
+            foreach ($inbound as $badOrder) {
                 $total += $badOrder->amount;
             }
+
             return $total;
         }
+
         return 0;
     }
 
     // per date
     // default is today
-    public static function getTotalOfAllInboundProducts($branchCode, $fromDate = null, $toDate = null){
+    public static function getTotalOfAllInboundProducts($branchCode, $fromDate = null, $toDate = null)
+    {
 
-        if($fromDate && $toDate){
+        if ($fromDate && $toDate) {
             $fromDate = date('Y-m-d', strtotime($fromDate));
             $toDate = date('Y-m-d', strtotime($toDate));
 
             $inbounds = Inbound::where('branch_code', $branchCode)
-            ->whereBetween('order_date', [$fromDate, $toDate])->whereNotIn('status', ['Cancelled', 'Wrong entry', 'Deleted'])
-            ->get();
+                ->whereBetween('order_date', [$fromDate, $toDate])->whereNotIn('status', ['Cancelled', 'Wrong entry', 'Deleted'])
+                ->get();
 
-        }else{
+        } else {
 
             $dateToExtract = date('Y-m-d');
 
-
             $inbounds = Inbound::where('branch_code', $branchCode)
-            ->whereDate('order_date', $dateToExtract)->whereNotIn('status', ['Cancelled', 'Wrong entry', 'Deleted'])
-            ->get();
+                ->whereDate('order_date', $dateToExtract)->whereNotIn('status', ['Cancelled', 'Wrong entry', 'Deleted'])
+                ->get();
 
         }
 
-
-
-
-
-        $products = $inbounds->flatMap(function ($inbound) {
-            $inboundProducts = json_decode($inbound->products, true);
-            return collect($inboundProducts)
-                ->map(function ($product) use ($inbound) {
-                    $productType = ProductType::code($product['ptype_code'])->first();
-                    return [
-                        'code' => $product['code'],
-                        'quantity' => $product['quantity'],
-                        'sequence_no' => $productType->sequence_no,
-                    ];
-                });
-        })
-            ->groupBy('code')
-            ->map(function ($group) {
-                return [
-                    'code' => $group->first()['code'],
-                    'quantity' => $group->sum('quantity'),
-                    'sequence_no' => $group->first()['sequence_no'],
-                ];
-            })
-            ->sortBy('sequence_no')
-            ->values()
-            ->toArray();
-
-        return $products;
+        return self::summarizeProductsByCode($inbounds);
     }
 
     public static function getTotalOfAllInboundProductsv2($branchCode) // ! PANG OVERALL
     {
 
         $inbounds = Inbound::where('branch_code', $branchCode)->whereNotIn('status', ['Cancelled', 'Wrong entry', 'Deleted'])->get();
+
         // $inbounds = Inbound::where('branch_code', $branchCode)->whereBetween('order_date', ['2024-08-19', '2024-08-21'])->get(); // ! uncomment if you want to filter by range of dates
-        $products = $inbounds->flatMap(function ($inbound) {
-            $inboundProducts = json_decode($inbound->products, true);
-            return collect($inboundProducts)
-                ->map(function ($product) use ($inbound) {
-                    $productType = ProductType::code($product['ptype_code'])->first();
-                    return [
-                        'code' => $product['code'],
-                        'quantity' => $product['quantity'],
-                        'sequence_no' => $productType->sequence_no,
-                    ];
-                });
+        return self::summarizeProductsByCode($inbounds);
+    }
+
+    /**
+     * Total quantity per product CODE, ordered by the product type's sequence_no.
+     *
+     * Shared by both getTotalOfAllInboundProducts* methods, which previously
+     * carried identical copies of this block.
+     *
+     * The product-type lookup is fetched ONCE up front. It used to run
+     * `ProductType::code($code)->first()` inside the per-line map — 9,040
+     * queries for a single month of one branch. It is now 1.
+     *
+     * Also hardened: a line naming a product type that no longer exists used to
+     * fatal on `$productType->sequence_no` (null dereference); such lines now
+     * sort last instead. Malformed lines are skipped rather than fataling.
+     *
+     * @param  \Illuminate\Support\Collection<int, \App\Models\Inbound>  $inbounds
+     * @return array<int, array{code: mixed, quantity: mixed, sequence_no: int}>
+     */
+    private static function summarizeProductsByCode($inbounds): array
+    {
+        $sequenceByType = ProductType::pluck('sequence_no', 'code');
+
+        return $inbounds->flatMap(function ($inbound) use ($sequenceByType) {
+            // json_decode(..., true) normalises both the array and the
+            // object-encoded ("{"0":{...}}") shapes found in production.
+            return collect(json_decode($inbound->products, true) ?: [])
+                ->filter(fn ($product) => is_array($product) && isset($product['code']))
+                ->map(fn ($product) => [
+                    'code' => $product['code'],
+                    'quantity' => $product['quantity'] ?? 0,
+                    'sequence_no' => $sequenceByType[$product['ptype_code'] ?? ''] ?? PHP_INT_MAX,
+                ]);
         })
             ->groupBy('code')
             ->map(function ($group) {
@@ -125,8 +124,6 @@ class InboundService extends Model
             ->sortBy('sequence_no')
             ->values()
             ->toArray();
-
-        return $products;
     }
 
     // create a function that gets all the inbounds that has delivery receipt
@@ -136,6 +133,4 @@ class InboundService extends Model
             ->has('deliveryReceipt')
             ->get();
     }
-
-
 }

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -15,11 +15,13 @@ doc it points to. Updated at every phase boundary and session end.
   `/reports/sales-by-product-type` responds on prod (302 → login, as expected
   for an authenticated route). Spec: `docs/specs/001-sales-by-product-type.md`.
 
-  **Merging `main` deploys to production.** The "Laravel" workflow is not a test
-  pipeline — on every push to `main` it SSHes to the VPS and runs
-  `git reset --hard origin/main && composer install --no-dev && php artisan
-  db:backup && php artisan migrate --force` plus cache warming. There is no CI
-  that runs the test suite. Treat every merge to `main` as a production deploy.
+  **On `.github/workflows/main.yml`:** it triggers on push to `main` and its
+  job body contains VPS deploy steps (`git reset --hard origin/main`,
+  `composer install --no-dev`, `artisan db:backup`, `artisan migrate --force`).
+  **Melvin, 2026-07-29: "merge is not deploying in this project"** — so do NOT
+  treat a merge as a release; the deploy path is not live as written. Either
+  way, note that this workflow runs **no tests**: there is no CI gate on `main`,
+  so the suite must be run locally before merging.
 
 ## BLOCKED
 
@@ -37,11 +39,6 @@ doc it points to. Updated at every phase boundary and session end.
   `CheckSessionBranch` middleware now changes to `branch-select`. Pre-existing;
   test drift rather than an app bug.
 
-- **N+1 in `InboundService::getTotalOfAllInboundProducts()`** — runs
-  `ProductType::code($code)->first()` inside the per-order-line loop, so a wide
-  date range on `/reports/products-summary` fires one query per line. Candidate
-  follow-up issue.
-
 ## FOLLOW-UPS
 
 - `main` still has no full schema in migrations; only the unmerged
@@ -54,6 +51,16 @@ doc it points to. Updated at every phase boundary and session end.
   `db/preventive-cleanup-phases` — pop it there, not on `main`.
 
 ## RESOLVED
+
+- **2026-07-29 — N+1 in `InboundService` (was PARKED).** Both
+  `getTotalOfAllInboundProducts()` and `…v2()` ran
+  `ProductType::code($code)->first()` inside the per-order-line map — **9,040
+  queries** for one month of one branch, and unbounded for `v2` (it scans every
+  order ever). The duplicated block is now one private
+  `summarizeProductsByCode()` helper with the lookup fetched once: **9,040 → 2
+  queries**, output byte-identical on real data. It also no longer fatals on a
+  line naming a product type that no longer exists (was a null dereference).
+  Covered by `tests/Feature/InboundServiceProductSummaryTest.php`, mutation-tested.
 
 - **2026-07-29 — `AppServiceProvider` null branch (was PARKED).** The global
   `view()->composer('*')` dereferenced `$branch->name` unguarded, so any session

--- a/tests/Feature/InboundServiceProductSummaryTest.php
+++ b/tests/Feature/InboundServiceProductSummaryTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Inbound;
+use App\Models\ProductType;
+use App\Models\User;
+use App\Services\InboundService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Covers InboundService::getTotalOfAllInboundProducts*, which back the
+ * /reports/products-summary screens. These used to run one ProductType query
+ * per order LINE (9,040 queries for a single month of one branch).
+ */
+class InboundServiceProductSummaryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected string $branchCode = 'EFTO-CAG';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // sequence_no is the inverse of alphabetical, so ordering can't pass by luck.
+        ProductType::create(['code' => 'TUBE', 'name' => 'Tube Ice', 'volume' => '1', 'sequence_no' => 1]);
+        ProductType::create(['code' => 'BLOCK', 'name' => 'Block Ice', 'volume' => '1', 'sequence_no' => 2]);
+    }
+
+    private function makeInbound(array|string $products, array $overrides = []): Inbound
+    {
+        static $orderNo = 0;
+        $orderNo++;
+
+        return Inbound::unguarded(fn () => Inbound::create(array_merge([
+            'branch_code' => $this->branchCode,
+            'customer_id' => 1,
+            'customer_name' => 'Test Customer',
+            'degic_no' => 'D-'.$orderNo,
+            'delivery_person' => 'Someone',
+            'delivery_person_id' => 1,
+            'driver_id' => '1',
+            'driver_name' => 'Driver',
+            'equipment_id' => '1',
+            'order_date' => now()->format('Y-m-d H:i:s'),
+            'order_no' => (string) $orderNo,
+            'pricelevel_id' => 1,
+            'status' => 'Completed',
+            'store_id' => 1,
+            'store_name' => 'Test Store',
+            'user_id' => User::factory()->create()->id,
+            'vehicle_id' => '1',
+            'vehicle_no' => 'ABC-123',
+            'products' => is_string($products) ? $products : json_encode($products),
+        ], $overrides)));
+    }
+
+    private function line(string $ptypeCode, string $code, float $qty): array
+    {
+        return ['ptype_code' => $ptypeCode, 'code' => $code, 'quantity' => $qty, 'price' => 10.0, 'order' => '1'];
+    }
+
+    public function test_it_totals_quantity_per_product_code(): void
+    {
+        $this->makeInbound([$this->line('TUBE', 'TUBE_S', 10), $this->line('TUBE', 'TUBE_L', 3)]);
+        $this->makeInbound([$this->line('TUBE', 'TUBE_S', 5)]);
+
+        $result = collect(InboundService::getTotalOfAllInboundProducts($this->branchCode))->keyBy('code');
+
+        $this->assertEquals(15, $result['TUBE_S']['quantity']);
+        $this->assertEquals(3, $result['TUBE_L']['quantity']);
+    }
+
+    public function test_it_orders_by_sequence_no_not_alphabetically(): void
+    {
+        $this->makeInbound([$this->line('BLOCK', 'BLOCK_A', 1), $this->line('TUBE', 'TUBE_Z', 1)]);
+
+        $codes = collect(InboundService::getTotalOfAllInboundProducts($this->branchCode))->pluck('code')->all();
+
+        // Alphabetically BLOCK_A precedes TUBE_Z; sequence_no puts TUBE first.
+        $this->assertSame(['TUBE_Z', 'BLOCK_A'], $codes);
+    }
+
+    /**
+     * The N+1 guard. Previously this ran one ProductType query per order line;
+     * the count must not grow with the number of lines.
+     */
+    public function test_it_does_not_query_product_types_per_line(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->makeInbound([
+                $this->line('TUBE', 'TUBE_S', 1),
+                $this->line('TUBE', 'TUBE_L', 1),
+                $this->line('BLOCK', 'BLOCK_A', 1),
+            ]);
+        }
+
+        DB::enableQueryLog();
+        InboundService::getTotalOfAllInboundProducts($this->branchCode);
+        $productTypeQueries = collect(DB::getQueryLog())
+            ->filter(fn ($q) => str_contains($q['query'], 'from `product_types`'))
+            ->count();
+        DB::disableQueryLog();
+
+        // 15 order lines, but the lookup is fetched once.
+        $this->assertSame(1, $productTypeQueries, 'product_types was queried per line (N+1)');
+    }
+
+    /**
+     * A line naming a product type that no longer exists used to fatal on
+     * `$productType->sequence_no`. It must now sort last instead.
+     */
+    public function test_a_line_with_an_unknown_product_type_does_not_error(): void
+    {
+        $this->makeInbound([$this->line('TUBE', 'TUBE_S', 1), $this->line('GONE', 'GONE_X', 2)]);
+
+        $result = collect(InboundService::getTotalOfAllInboundProducts($this->branchCode));
+
+        $this->assertSame(['TUBE_S', 'GONE_X'], $result->pluck('code')->all());
+        $this->assertEquals(2, $result->keyBy('code')['GONE_X']['quantity']);
+    }
+
+    public function test_it_counts_object_encoded_products_json(): void
+    {
+        $this->makeInbound('{"0":'.json_encode($this->line('TUBE', 'TUBE_S', 7)).'}');
+
+        $result = collect(InboundService::getTotalOfAllInboundProducts($this->branchCode))->keyBy('code');
+
+        $this->assertEquals(7, $result['TUBE_S']['quantity']);
+    }
+
+    public function test_v2_totals_across_all_dates(): void
+    {
+        $this->makeInbound([$this->line('TUBE', 'TUBE_S', 2)], ['order_date' => '2024-01-01 09:00:00']);
+        $this->makeInbound([$this->line('TUBE', 'TUBE_S', 3)], ['order_date' => now()->format('Y-m-d H:i:s')]);
+
+        $result = collect(InboundService::getTotalOfAllInboundProductsv2($this->branchCode))->keyBy('code');
+
+        $this->assertEquals(5, $result['TUBE_S']['quantity']);
+    }
+
+    public function test_it_excludes_cancelled_and_deleted_orders(): void
+    {
+        $this->makeInbound([$this->line('TUBE', 'TUBE_S', 4)]);
+        $this->makeInbound([$this->line('TUBE', 'TUBE_S', 99)], ['status' => 'Cancelled']);
+        $this->makeInbound([$this->line('TUBE', 'TUBE_S', 99)], ['status' => 'Deleted']);
+        $this->makeInbound([$this->line('TUBE', 'TUBE_S', 99)], ['status' => 'Wrong entry']);
+
+        $result = collect(InboundService::getTotalOfAllInboundProducts($this->branchCode))->keyBy('code');
+
+        $this->assertEquals(4, $result['TUBE_S']['quantity']);
+    }
+}


### PR DESCRIPTION
Removes the N+1 parked in `docs/STATE.md`.

## The problem

`InboundService::getTotalOfAllInboundProducts()` and `getTotalOfAllInboundProductsv2()` — which back the `/products-summary` reports — each ran `ProductType::code($code)->first()` **inside the per-order-line map**.

Measured against restored production data, one month of one branch (EFTO-CAG, June 2026):

| | queries |
|---|---|
| before | **9,040** |
| after | **2** |

`v2` is worse in principle: it has no date filter, so it scanned every order ever recorded (11,895 and growing) at one query per line. It now runs in 2 queries / 0.81s.

Both methods also carried **identical copies** of the same ~25-line block, so the fix consolidates them into one private `summarizeProductsByCode()` helper rather than fixing the same bug twice.

## Also fixed while in there

A line naming a product type that no longer exists fataled on `$productType->sequence_no` — a null dereference of exactly the same class as the `AppServiceProvider` one fixed in #44. Such lines now sort last. Malformed lines are skipped rather than fataling. No production row currently trips this (verified: zero unknown `ptype_code`s across all orders), so it was latent.

## Verification

- **Output is byte-identical** on real data — the same 99 rows, captured before and after and diffed.
- **Rendered check**: `/products-summary-filtered` for the same range renders the same 99 rows in the same product-type sequence order.
- **7 new tests**, all green; 23 green across the related suites.
- **Mutation-tested**: restoring the per-line lookup turns both the N+1 test and the unknown-product-type test red.

Behaviour is unchanged for well-formed data; only the query count and the failure modes improve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)